### PR TITLE
Support for classifier + fix issue when only one snapshot in repo.

### DIFF
--- a/scripted_deploy/update-service.test.sh
+++ b/scripted_deploy/update-service.test.sh
@@ -32,7 +32,25 @@ find_artifact_test() {
     fi
 
     find_artifact "SNAPSHOT" jarfile url
+    echo "$URL"
     if [[ ! "$url" == *SNAPSHOT*.jar ]]; then
+        echoerr "EXPECTED:  to contain SNAPSHOT"
+        echoerr "ACTUAL:    $jarfile - $url"
+        FAILED=true
+    fi
+
+    # Find release with classifier
+    CLASSIFIER=jar-with-dependencies
+    find_artifact "2.4.19" jarfile url
+    if [[ "$jarfile" != "SecurityTokenService-2.4.19-jar-with-dependencies.jar" && "$url" != "https://mvnrepo.cantara.no/content/repositories/releases/net/whydah/token/SecurityTokenService/2.4.19/SecurityTokenService-2.4.19-jar-with-dependencies.jar" ]]; then
+        echoerr "EXPECTED:  SecurityTokenService-2.4.19-jar-with-dependencies.jar - https://mvnrepo.cantara.no/content/repositories/releases/net/whydah/token/SecurityTokenService/2.4.19/SecurityTokenService-2.4.19-jar-with-dependencies.jar"
+        echoerr "ACTUAL:    $jarfile - $url"
+        FAILED=true
+    fi
+
+    # Find snapshot with classifier
+    find_artifact "SNAPSHOT" jarfile url
+    if [[ ! "$url" == *SNAPSHOT*.jar ]] && [[ ! "$url" == *$CLASSIFIER ]]; then
         echoerr "EXPECTED:  to contain SNAPSHOT"
         echoerr "ACTUAL:    $jarfile - $url"
         FAILED=true


### PR DESCRIPTION
Script can be configured to download artifacts with classifiers - e.g. like `jar-with-dependencies` in `https://mvnrepo.cantara.no/content/repositories/snapshots/org/valuereporter/valuereporter-statsd-agent/0.23-SNAPSHOT/valuereporter-statsd-agent-0.23-20180907.092326-4-jar-with-dependencies.jar`

Also fixed issue where script would fail if only one snapshot existed in repo and thus <latest> tag in maven-metadata.xml is not set.

